### PR TITLE
Fix WPML portfolio duplication

### DIFF
--- a/compatibility/compatibility.php
+++ b/compatibility/compatibility.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * 3rd party plugins & themes compatibility.
+ * Load files individually.
+ *
+ * @since 1.1.2
+ */
+
+/**
+ * This file should work without errors on PHP 5.2.17
+ * Use this instead of __DIR__
+ */
+$__DIR = dirname( __FILE__ );
+
+require_once $__DIR . '/wpml.php';

--- a/compatibility/wpml.php
+++ b/compatibility/wpml.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * WPML plugin related compatibility code.
+ * Loaded only if WPML plugin is installed and active.
+ *
+ * @since 1.1.2
+ */
+
+/**
+ * Load routines only if WPML is loaded.
+ *
+ * @since 1.1.2
+ */
+function wpml_phort_init() {
+
+	/**
+	 * Since it is only relevant when WPML Media plugin is activated.
+	 */
+	if ( defined( 'WPML_MEDIA_VERSION' ) ) {
+		add_filter( 'wpml_duplicate_generic_string', 'wpml_phort_postmeta_duplication', 10, 3 );
+	}
+}
+
+add_action( 'wpml_loaded', 'wpml_phort_init' );
+
+
+/**
+ * Translating image IDs if portfolio post is duplicated.
+ *
+ * @since 1.1.2
+ */
+function wpml_phort_postmeta_duplication( $value_to_filter, $target_language, $meta_data ) {
+	if ( $meta_data['key'] !== 'phort_gallery' ) {
+		return $value_to_filter;
+	}
+
+	$gallery            = maybe_unserialize( $value_to_filter );
+	$translated_gallery = array();
+
+	foreach ( $gallery as $image_id => $url ) {
+		$translated_image_id = apply_filters( 'wpml_object_id', $image_id, 'attachment', true, $target_language );
+		$translated_gallery[ $translated_image_id ] = $url;
+	}
+
+	return $translated_gallery;
+}

--- a/photography-portfolio.php
+++ b/photography-portfolio.php
@@ -103,4 +103,12 @@ else {
 	add_action( 'after_setup_theme', 'phort_instance' );
 
 
+    /**
+     * 3rd party plugins & themes compatibility
+     *
+     * @since 1.1.2
+     */
+    require_once $__DIR . '/compatibility/compatibility.php';
+
+
 }


### PR DESCRIPTION
For now we are dealing just with image IDs which means that title, caption, etc.. will be transalted automatically. There is still issue left with image URL path which is pointing to default language, I will update this at some point.

You just need to update plugin version.
I have put @since to 1.1.2 

Cheers!